### PR TITLE
WidgetEventBus: Extend widget event bus to handle multiple ids

### DIFF
--- a/lib/core/bus/widget_event_bus/neo_widget_event_bus.dart
+++ b/lib/core/bus/widget_event_bus/neo_widget_event_bus.dart
@@ -17,27 +17,32 @@ import 'package:rxdart/rxdart.dart';
 
 class NeoWidgetEventBus {
   final _eventBus = BehaviorSubject<NeoWidgetEvent>();
+  final Set<StreamSubscription<NeoWidgetEvent>> _subscriptions = {};
 
   StreamSubscription<NeoWidgetEvent> listen({
     required String eventId,
     required Function(NeoWidgetEvent) onEventReceived,
   }) {
-    return _eventBus.stream.listen((event) {
+    final subscription = _eventBus.stream.listen((event) {
       if (event.eventId == eventId) {
         onEventReceived(event);
       }
     });
+    _subscriptions.add(subscription);
+    return subscription;
   }
 
   StreamSubscription<NeoWidgetEvent> listenEvents({
     required List<String> eventIds,
     required Function(NeoWidgetEvent) onEventReceived,
   }) {
-    return _eventBus.stream.listen((event) {
+    final subscription = _eventBus.stream.listen((event) {
       if (eventIds.contains(event.eventId)) {
         onEventReceived(event);
       }
     });
+    _subscriptions.add(subscription);
+    return subscription;
   }
 
   void addEvent(NeoWidgetEvent event) {
@@ -45,6 +50,10 @@ class NeoWidgetEventBus {
   }
 
   void close() {
+    for (final subscription in _subscriptions) {
+      subscription.cancel();
+    }
+    _subscriptions.clear();
     _eventBus.close();
   }
 }

--- a/lib/core/bus/widget_event_bus/neo_widget_event_bus.dart
+++ b/lib/core/bus/widget_event_bus/neo_widget_event_bus.dart
@@ -10,18 +10,31 @@
  * Any reproduction of this material must contain this notice.
  */
 
+import 'dart:async';
+
 import 'package:neo_core/core/bus/widget_event_bus/neo_widget_event.dart';
 import 'package:rxdart/rxdart.dart';
 
 class NeoWidgetEventBus {
   final _eventBus = BehaviorSubject<NeoWidgetEvent>();
 
-  void listen({
+  StreamSubscription<NeoWidgetEvent> listen({
     required String eventId,
     required Function(NeoWidgetEvent) onEventReceived,
   }) {
-    _eventBus.stream.listen((event) {
+    return _eventBus.stream.listen((event) {
       if (event.eventId == eventId) {
+        onEventReceived(event);
+      }
+    });
+  }
+
+  StreamSubscription<NeoWidgetEvent> listenEvents({
+    required List<String> eventIds,
+    required Function(NeoWidgetEvent) onEventReceived,
+  }) {
+    return _eventBus.stream.listen((event) {
+      if (eventIds.contains(event.eventId)) {
         onEventReceived(event);
       }
     });
@@ -29,5 +42,9 @@ class NeoWidgetEventBus {
 
   void addEvent(NeoWidgetEvent event) {
     _eventBus.add(event);
+  }
+
+  void close() {
+    _eventBus.close();
   }
 }


### PR DESCRIPTION
Also return subscription result to stop listening

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Introduced the ability to listen to multiple events in the widget event system.

- **Enhancements**
  - Event listeners now return a `StreamSubscription` for better control over event handling.

- **Bug Fixes**
  - Added a `close` method to properly shut down the event bus when no longer needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->