### PR TITLE
Hotfix: Remove A-Customer from default headers

### DIFF
--- a/lib/core/network/managers/neo_network_manager.dart
+++ b/lib/core/network/managers/neo_network_manager.dart
@@ -58,7 +58,6 @@ class NeoNetworkManager {
       secureStorage.getTokenId(),
       secureStorage.getDeviceInfo(),
       _authHeader,
-      _customerIdHeader,
     ]);
 
     final languageCode = results[0] as String? ?? "";
@@ -66,7 +65,6 @@ class NeoNetworkManager {
     final tokenId = results[2] as String? ?? "";
     final deviceInfo = results[3] as String? ?? "";
     final authHeader = results[4] as Map<String, String>? ?? {};
-    final customerIdHeader = results[5] as Map<String, String>? ?? {};
 
     return {
       NeoNetworkHeaderKey.contentType: _Constants.headerValueContentType,
@@ -77,19 +75,12 @@ class NeoNetworkManager {
       NeoNetworkHeaderKey.tokenId: tokenId,
       NeoNetworkHeaderKey.requestId: const Uuid().v1(),
       NeoNetworkHeaderKey.deviceInfo: deviceInfo,
-    }
-      ..addAll(authHeader)
-      ..addAll(customerIdHeader);
+    }..addAll(authHeader);
   }
 
   Future<Map<String, String>> get _authHeader async {
     final authToken = await secureStorage.getAuthToken();
     return authToken == null ? {} : {NeoNetworkHeaderKey.authorization: 'Bearer $authToken'};
-  }
-
-  Future<Map<String, String>> get _customerIdHeader async {
-    final customerId = await secureStorage.getCustomerId();
-    return customerId == null ? {} : {NeoNetworkHeaderKey.customer: customerId};
   }
 
   Future<Map<String, String>> get _defaultPostHeaders async => <String, String>{}

--- a/lib/core/network/models/neo_network_header_key.dart
+++ b/lib/core/network/models/neo_network_header_key.dart
@@ -20,7 +20,6 @@ abstract class NeoNetworkHeaderKey {
   static const requestId = "X-Request-Id";
   static const deviceInfo = "X-Device-Info";
   static const authorization = "Authorization";
-  static const customer = "A-Customer";
   static const user = "User";
   static const behalfOfUser = "Behalf-Of-User";
   static const accessToken = "access_token";


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified network header management by removing customer-specific headers and focusing on authentication headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->