### PR TITLE
Hotfix: Add loading state during workflow init

### DIFF
--- a/lib/core/widgets/neo_transition_listener/bloc/neo_transition_listener_bloc.dart
+++ b/lib/core/widgets/neo_transition_listener/bloc/neo_transition_listener_bloc.dart
@@ -41,6 +41,14 @@ class NeoTransitionListenerBloc extends Bloc<NeoTransitionListenerEvent, NeoTran
     on<NeoTransitionListenerEventPostTransition>((event, emit) => _onPostTransition(event));
   }
 
+  @override
+  Future<Map<String, dynamic>> initWorkflow(String workflowName) async {
+    onLoadingStatusChanged(displayLoading: true);
+    final response = await super.initWorkflow(workflowName);
+    onLoadingStatusChanged(displayLoading: false);
+    return response;
+  }
+
   Future<void> _onInit(NeoTransitionListenerEventInit event) async {
     onPageNavigation = event.onPageNavigation;
     onLoggedInSuccessfully = event.onLoggedInSuccessfully;

--- a/lib/core/widgets/neo_transition_listener/bloc/neo_transition_listener_bloc.dart
+++ b/lib/core/widgets/neo_transition_listener/bloc/neo_transition_listener_bloc.dart
@@ -43,10 +43,14 @@ class NeoTransitionListenerBloc extends Bloc<NeoTransitionListenerEvent, NeoTran
 
   @override
   Future<Map<String, dynamic>> initWorkflow(String workflowName) async {
-    onLoadingStatusChanged(displayLoading: true);
-    final response = await super.initWorkflow(workflowName);
-    onLoadingStatusChanged(displayLoading: false);
-    return response;
+    try {
+      onLoadingStatusChanged(displayLoading: true);
+      return await super.initWorkflow(workflowName);
+    } catch (e) {
+      rethrow;
+    } finally {
+      onLoadingStatusChanged(displayLoading: false);
+    }
   }
 
   Future<void> _onInit(NeoTransitionListenerEventInit event) async {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Improved the loading status handling in the transition listener for a smoother user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->