### PR TITLE
Feature/huawei push

### DIFF
--- a/lib/core/widgets/neo_core_firebase_messaging/neo_core_firebase_messaging.dart
+++ b/lib/core/widgets/neo_core_firebase_messaging/neo_core_firebase_messaging.dart
@@ -74,8 +74,6 @@ class _NeoCoreFirebaseMessagingState extends State<NeoCoreFirebaseMessaging> {
 
   Future<void> _initNotifications() async {
     final token = await _getTokenBasedOnPlatform();
-    debugPrint("*** TOKEN: $token");
-    print("*** TOKEN: $token");
     if (token != null) {
       _onTokenChange(token);
     }

--- a/lib/core/widgets/neo_core_firebase_messaging/neo_core_firebase_messaging.dart
+++ b/lib/core/widgets/neo_core_firebase_messaging/neo_core_firebase_messaging.dart
@@ -74,6 +74,8 @@ class _NeoCoreFirebaseMessagingState extends State<NeoCoreFirebaseMessaging> {
 
   Future<void> _initNotifications() async {
     final token = await _getTokenBasedOnPlatform();
+    debugPrint("*** TOKEN: $token");
+    print("*** TOKEN: $token");
     if (token != null) {
       _onTokenChange(token);
     }

--- a/lib/core/widgets/neo_core_huawei_messaging/neo_core_huawei_messaging.dart
+++ b/lib/core/widgets/neo_core_huawei_messaging/neo_core_huawei_messaging.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:developer';
 
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
@@ -131,12 +132,15 @@ class _NeoCoreHuaweiMessagingState extends State<NeoCoreHuaweiMessaging> {
       // Listen to the token stream
       Push.getTokenStream.listen((token) {
         if (token != null) {
-          debugPrint("Huawei Push token: $token");
+          log("Huawei Push token: $token");
+          print("Huawei Push token: $token");
           _onTokenChange(token);
         }
       });
     } catch (e) {
       debugPrint("Error getting Huawei push token: $e");
+      print("Error getting Huawei push token: $e");
+      log("Error getting Huawei push token: $e");
     }
   }
 
@@ -171,5 +175,7 @@ class _NeoCoreHuaweiMessagingState extends State<NeoCoreHuaweiMessaging> {
 
   void _onMessageReceiveError(Object error) {
     debugPrint("Error receiving message: $error");
+    print("Error receiving message: $error");
+    log("Error receiving message: $error");
   }
 }

--- a/lib/core/widgets/neo_core_huawei_messaging/neo_core_huawei_messaging.dart
+++ b/lib/core/widgets/neo_core_huawei_messaging/neo_core_huawei_messaging.dart
@@ -83,6 +83,8 @@ class _NeoCoreHuaweiMessagingState extends State<NeoCoreHuaweiMessaging> {
   }
 
   void _onTokenChange(String token) {
+    log("Huawei Push token: $token");
+    print("Huawei Push token: $token");
     NeoCoreRegisterDeviceUseCase().call(
       networkManager: widget.networkManager,
       secureStorage: widget.neoCoreSecureStorage,
@@ -131,9 +133,8 @@ class _NeoCoreHuaweiMessagingState extends State<NeoCoreHuaweiMessaging> {
 
       // Listen to the token stream
       Push.getTokenStream.listen((token) {
+        log("listen Token:");
         if (token != null) {
-          log("Huawei Push token: $token");
-          print("Huawei Push token: $token");
           _onTokenChange(token);
         }
       });

--- a/lib/core/widgets/neo_core_huawei_messaging/neo_core_huawei_messaging.dart
+++ b/lib/core/widgets/neo_core_huawei_messaging/neo_core_huawei_messaging.dart
@@ -61,8 +61,8 @@ class _NeoCoreHuaweiMessagingState extends State<NeoCoreHuaweiMessaging> {
     if (kIsWeb) {
       return;
     }
-    _initNotifications();
     _initPushNotifications();
+    _initNotifications();
     if (Platform.isAndroid) {
       _initLocalNotifications();
     }
@@ -125,8 +125,6 @@ class _NeoCoreHuaweiMessagingState extends State<NeoCoreHuaweiMessaging> {
 
   Future<void> _getHuaweiToken() async {
     try {
-      await Push.turnOnPush();
-
       // Request token (token will be sent via Push.getTokenStream)
       Push.getToken(""); // Request the token with an empty string
 

--- a/lib/core/widgets/neo_core_huawei_messaging/neo_core_huawei_messaging.dart
+++ b/lib/core/widgets/neo_core_huawei_messaging/neo_core_huawei_messaging.dart
@@ -1,0 +1,177 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter/material.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:huawei_push/huawei_push.dart'; // Huawei Push Kit
+import 'package:neo_core/core/network/managers/neo_network_manager.dart';
+import 'package:neo_core/core/storage/neo_core_secure_storage.dart';
+import 'package:neo_core/feature/device_registration/usecases/neo_core_register_device_usecase.dart';
+import 'package:universal_io/io.dart';
+
+abstract class _Constant {
+  static const androidNotificationChannelID = "high_importance_channel";
+  static const androidNotificationChannelName = "High Importance Notifications";
+  static const androidNotificationChannelDescription = "This channel is used for important notifications";
+  static const pushNotificationDeeplinkKey = "deeplink";
+}
+
+@pragma('vm:entry-point')
+Future<void> onBackgroundMessage(RemoteMessage message) async {
+  return Future.value();
+}
+
+class NeoCoreHuaweiMessaging extends StatefulWidget {
+  const NeoCoreHuaweiMessaging({
+    required this.child,
+    required this.networkManager,
+    required this.neoCoreSecureStorage,
+    this.androidDefaultIcon,
+    this.onDeeplinkNavigation,
+    super.key,
+  });
+
+  final Widget child;
+  final NeoNetworkManager networkManager;
+  final NeoCoreSecureStorage neoCoreSecureStorage;
+  final String? androidDefaultIcon;
+  final Function(String)? onDeeplinkNavigation;
+
+  @override
+  State<NeoCoreHuaweiMessaging> createState() => _NeoCoreHuaweiMessagingState();
+}
+
+class _NeoCoreHuaweiMessagingState extends State<NeoCoreHuaweiMessaging> {
+  final _androidChannel = const AndroidNotificationChannel(
+    _Constant.androidNotificationChannelID,
+    _Constant.androidNotificationChannelName,
+    description: _Constant.androidNotificationChannelDescription,
+  );
+  final _localNotifications = FlutterLocalNotificationsPlugin();
+
+  @override
+  Widget build(BuildContext context) {
+    return widget.child;
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    if (kIsWeb) {
+      return;
+    }
+    _initNotifications();
+    _initPushNotifications();
+    if (Platform.isAndroid) {
+      _initLocalNotifications();
+    }
+  }
+
+  Future<void> _initNotifications() async {
+    await _getHuaweiToken();
+
+    // Listen to the token stream
+    Push.getTokenStream.listen(_onTokenChange);
+
+    // Listen to the message received stream
+    Push.onMessageReceivedStream.listen(_onMessageReceived, onError: _onMessageReceiveError);
+
+    // Listen to notification opened events
+    Push.onNotificationOpenedApp.listen(_onNotificationOpenedApp);
+  }
+
+  void _onTokenChange(String token) {
+    NeoCoreRegisterDeviceUseCase().call(
+      networkManager: widget.networkManager,
+      secureStorage: widget.neoCoreSecureStorage,
+      deviceToken: token,
+    );
+  }
+
+  Future<void> _initPushNotifications() async {
+    // Enable push notifications for Huawei Push Kit
+    await Push.turnOnPush();
+  }
+
+  Future<void> _initLocalNotifications() async {
+    final String androidIcon = widget.androidDefaultIcon ?? "";
+    final android = AndroidInitializationSettings(androidIcon);
+    final settings = InitializationSettings(android: android);
+
+    await _localNotifications.initialize(
+      settings,
+      onDidReceiveNotificationResponse: (NotificationResponse notificationResponse) {
+        final String? payload = notificationResponse.payload;
+        if (payload != null) {
+          // Directly handle the JSON payload from the notification
+          final Map<String, dynamic> messageData = jsonDecode(payload) as Map<String, dynamic>;
+          _handleMessage(messageData);
+        }
+      },
+    );
+
+    await _localNotifications
+        .resolvePlatformSpecificImplementation<AndroidFlutterLocalNotificationsPlugin>()
+        ?.createNotificationChannel(_androidChannel);
+  }
+
+  void _handleMessage(Map<String, dynamic> messageData) {
+    final String? deeplinkPath = messageData[_Constant.pushNotificationDeeplinkKey];
+    if (deeplinkPath != null && deeplinkPath.isNotEmpty) {
+      widget.onDeeplinkNavigation?.call(deeplinkPath);
+    }
+  }
+
+  Future<void> _getHuaweiToken() async {
+    try {
+      await Push.turnOnPush();
+
+      // Request token (token will be sent via Push.getTokenStream)
+      Push.getToken(""); // Request the token with an empty string
+
+      // Listen to the token stream
+      Push.getTokenStream.listen((token) {
+        if (token != null) {
+          debugPrint("Huawei Push token: $token");
+          _onTokenChange(token);
+        }
+      });
+    } catch (e) {
+      debugPrint("Error getting Huawei push token: $e");
+    }
+  }
+
+  void _onMessageReceived(RemoteMessage message) {
+    final notification = message.notification;
+    if (notification == null || !Platform.isAndroid) {
+      return;
+    }
+    _localNotifications.show(
+      notification.hashCode,
+      notification.title,
+      notification.body,
+      NotificationDetails(
+        android: AndroidNotificationDetails(
+          _androidChannel.id,
+          _androidChannel.name,
+          channelDescription: _androidChannel.description,
+          icon: widget.androidDefaultIcon,
+        ),
+      ),
+      payload: jsonEncode(message.data),
+    );
+  }
+
+  void _onNotificationOpenedApp(dynamic initialNotification) {
+    if (initialNotification != null) {
+      // Handle the initialNotification as a Map<String, dynamic>
+      final Map<String, dynamic> messageData = initialNotification as Map<String, dynamic>;
+      _handleMessage(messageData);
+    }
+  }
+
+  void _onMessageReceiveError(Object error) {
+    debugPrint("Error receiving message: $error");
+  }
+}

--- a/lib/core/widgets/neo_core_huawei_messaging/neo_core_huawei_messaging.dart
+++ b/lib/core/widgets/neo_core_huawei_messaging/neo_core_huawei_messaging.dart
@@ -69,7 +69,10 @@ class _NeoCoreHuaweiMessagingState extends State<NeoCoreHuaweiMessaging> {
   }
 
   Future<void> _initNotifications() async {
-    await _getHuaweiToken();
+    final token = await _getHuaweiToken();
+    if (token != null) {
+      _onTokenChange(token);
+    }
 
     // Listen to the token stream
     Push.getTokenStream.listen(_onTokenChange);
@@ -123,19 +126,18 @@ class _NeoCoreHuaweiMessagingState extends State<NeoCoreHuaweiMessaging> {
     }
   }
 
-  Future<void> _getHuaweiToken() async {
+  Future<String?> _getHuaweiToken() async {
     try {
       // Request token (token will be sent via Push.getTokenStream)
-      Push.getToken(""); // Request the token with an empty string
+      Push.getToken("");
 
-      // Listen to the token stream
-      Push.getTokenStream.listen((token) {
-        if (token != null) {
-          _onTokenChange(token);
-        }
-      });
+      // Listen to the first token from stream
+      final String token = await Push.getTokenStream.first;
+
+      return token;
     } catch (e) {
-      debugPrint("Error getting Huawei push token: $e");
+      debugPrint("Huawei push token alınırken hata oluştu: $e");
+      return null;
     }
   }
 

--- a/lib/core/widgets/neo_core_huawei_messaging/neo_core_huawei_messaging.dart
+++ b/lib/core/widgets/neo_core_huawei_messaging/neo_core_huawei_messaging.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:developer';
 
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
@@ -83,8 +82,6 @@ class _NeoCoreHuaweiMessagingState extends State<NeoCoreHuaweiMessaging> {
   }
 
   void _onTokenChange(String token) {
-    log("Huawei Push token: $token");
-    print("Huawei Push token: $token");
     NeoCoreRegisterDeviceUseCase().call(
       networkManager: widget.networkManager,
       secureStorage: widget.neoCoreSecureStorage,
@@ -133,15 +130,12 @@ class _NeoCoreHuaweiMessagingState extends State<NeoCoreHuaweiMessaging> {
 
       // Listen to the token stream
       Push.getTokenStream.listen((token) {
-        log("listen Token:");
         if (token != null) {
           _onTokenChange(token);
         }
       });
     } catch (e) {
       debugPrint("Error getting Huawei push token: $e");
-      print("Error getting Huawei push token: $e");
-      log("Error getting Huawei push token: $e");
     }
   }
 
@@ -176,7 +170,5 @@ class _NeoCoreHuaweiMessagingState extends State<NeoCoreHuaweiMessaging> {
 
   void _onMessageReceiveError(Object error) {
     debugPrint("Error receiving message: $error");
-    print("Error receiving message: $error");
-    log("Error receiving message: $error");
   }
 }

--- a/lib/core/widgets/neo_core_huawei_messaging/neo_core_huawei_messaging.dart
+++ b/lib/core/widgets/neo_core_huawei_messaging/neo_core_huawei_messaging.dart
@@ -85,6 +85,7 @@ class _NeoCoreHuaweiMessagingState extends State<NeoCoreHuaweiMessaging> {
   }
 
   void _onTokenChange(String token) {
+    debugPrint("Huawei Push token: $token");
     NeoCoreRegisterDeviceUseCase().call(
       networkManager: widget.networkManager,
       secureStorage: widget.neoCoreSecureStorage,
@@ -133,10 +134,9 @@ class _NeoCoreHuaweiMessagingState extends State<NeoCoreHuaweiMessaging> {
 
       // Listen to the first token from stream
       final String token = await Push.getTokenStream.first;
-
       return token;
     } catch (e) {
-      debugPrint("Huawei push token alınırken hata oluştu: $e");
+      debugPrint("There is an error receiving the Huawei-Push token: $e");
       return null;
     }
   }

--- a/lib/core/widgets/neo_core_messaging/neo_core_messaging.dart
+++ b/lib/core/widgets/neo_core_messaging/neo_core_messaging.dart
@@ -5,10 +5,9 @@ import 'package:neo_core/core/network/managers/neo_network_manager.dart';
 import 'package:neo_core/core/storage/neo_core_secure_storage.dart';
 import 'package:neo_core/core/widgets/neo_core_firebase_messaging/neo_core_firebase_messaging.dart';
 import 'package:neo_core/core/widgets/neo_core_huawei_messaging/neo_core_huawei_messaging.dart';
-import 'package:universal_io/io.dart';
 
 class NeoCoreMessaging extends StatelessWidget {
-  final bool isGooglePlayServicesAvailable;
+  final bool isHuaweiCompatible;
   final Widget child;
   final NeoNetworkManager networkManager;
   final NeoCoreSecureStorage neoCoreSecureStorage;
@@ -16,7 +15,7 @@ class NeoCoreMessaging extends StatelessWidget {
   final Function(String)? onDeeplinkNavigation;
 
   const NeoCoreMessaging({
-    required this.isGooglePlayServicesAvailable,
+    required this.isHuaweiCompatible,
     required this.child,
     required this.networkManager,
     required this.neoCoreSecureStorage,
@@ -29,8 +28,8 @@ class NeoCoreMessaging extends StatelessWidget {
   Widget build(BuildContext context) {
     if (kIsWeb) {
       return child;
-    } else if (Platform.isIOS || isGooglePlayServicesAvailable) {
-      return NeoCoreFirebaseMessaging(
+    } else if (isHuaweiCompatible) {
+      return NeoCoreHuaweiMessaging(
         networkManager: networkManager,
         neoCoreSecureStorage: neoCoreSecureStorage,
         androidDefaultIcon: androidDefaultIcon,
@@ -38,7 +37,7 @@ class NeoCoreMessaging extends StatelessWidget {
         child: child,
       );
     } else {
-      return NeoCoreHuaweiMessaging(
+      return NeoCoreFirebaseMessaging(
         networkManager: networkManager,
         neoCoreSecureStorage: neoCoreSecureStorage,
         androidDefaultIcon: androidDefaultIcon,

--- a/lib/core/widgets/neo_core_messaging/neo_core_messaging.dart
+++ b/lib/core/widgets/neo_core_messaging/neo_core_messaging.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter/material.dart';
+import 'package:neo_core/core/network/managers/neo_network_manager.dart';
+import 'package:neo_core/core/storage/neo_core_secure_storage.dart';
+import 'package:neo_core/core/widgets/neo_core_firebase_messaging/neo_core_firebase_messaging.dart';
+import 'package:neo_core/core/widgets/neo_core_huawei_messaging/neo_core_huawei_messaging.dart';
+import 'package:universal_io/io.dart';
+
+class NeoCoreMessaging extends StatelessWidget {
+  final bool isGooglePlayServicesAvailable;
+  final Widget child;
+  final NeoNetworkManager networkManager;
+  final NeoCoreSecureStorage neoCoreSecureStorage;
+  final String? androidDefaultIcon;
+  final Function(String)? onDeeplinkNavigation;
+
+  const NeoCoreMessaging({
+    required this.isGooglePlayServicesAvailable,
+    required this.child,
+    required this.networkManager,
+    required this.neoCoreSecureStorage,
+    this.androidDefaultIcon,
+    this.onDeeplinkNavigation,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (kIsWeb) {
+      return child;
+    } else if (Platform.isIOS || isGooglePlayServicesAvailable) {
+      return NeoCoreFirebaseMessaging(
+        networkManager: networkManager,
+        neoCoreSecureStorage: neoCoreSecureStorage,
+        androidDefaultIcon: androidDefaultIcon,
+        onDeeplinkNavigation: onDeeplinkNavigation,
+        child: child,
+      );
+    } else {
+      return NeoCoreHuaweiMessaging(
+        networkManager: networkManager,
+        neoCoreSecureStorage: neoCoreSecureStorage,
+        androidDefaultIcon: androidDefaultIcon,
+        onDeeplinkNavigation: onDeeplinkNavigation,
+        child: child,
+      );
+    }
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -544,6 +544,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.2"
+  huawei_push:
+    dependency: "direct main"
+    description:
+      name: huawei_push
+      sha256: "94c70987591442e301745e881ee2768ca5349800294bb7bdd46f9f80d1096c53"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.12.0+302"
   interpolation:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,6 +44,9 @@ dependencies:
   flutter_local_notifications: ^16.2.0
   firebase_messaging: ^14.7.9
 
+  #Huawei
+  huawei_push: ^6.12.0+302
+
   # Analytics
   posthog_flutter: ^3.3.0
   logger: ^2.2.0


### PR DESCRIPTION
We are adding Huawei push notifications. Taking into account the Huawei guide, we split the Firebase message and Huawei message classes into two. We bring the message service class to be used over a core class

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a widget for managing Huawei push notifications.
	- Added a flexible messaging solution that adapts to web, Android, and Huawei devices.
	- Enhanced app capabilities for handling push notifications and user navigation on Huawei devices.
	- Integrated support for Huawei's push notification services.

- **Chores**
	- Updated project dependencies to include the `huawei_push` package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->