### PR TITLE
Dengage: differ apns token for ios

### DIFF
--- a/lib/core/widgets/neo_core_firebase_messaging/neo_core_firebase_messaging.dart
+++ b/lib/core/widgets/neo_core_firebase_messaging/neo_core_firebase_messaging.dart
@@ -35,7 +35,6 @@ class NeoCoreFirebaseMessaging extends StatefulWidget {
     required this.networkManager,
     required this.neoCoreSecureStorage,
     required this.onTokenChanged,
-    required this.onAPNSTokenChanged,
     this.androidDefaultIcon,
     this.onDeeplinkNavigation,
     super.key,
@@ -45,7 +44,6 @@ class NeoCoreFirebaseMessaging extends StatefulWidget {
   final NeoNetworkManager networkManager;
   final NeoCoreSecureStorage neoCoreSecureStorage;
   final Function(String) onTokenChanged;
-  final Function(String) onAPNSTokenChanged;
   final String? androidDefaultIcon;
   final Function(String)? onDeeplinkNavigation;
 
@@ -126,7 +124,7 @@ class _NeoCoreFirebaseMessagingState extends State<NeoCoreFirebaseMessaging> {
   void _onAPNSTokenChange(String tokenApns) {
     _neoLogger.logConsole("[NeoCoreFirebaseMessaging]: Firebase APNS token is: $tokenApns");
     if (Platform.isIOS) {
-      widget.onAPNSTokenChanged.call(tokenApns);
+      widget.onTokenChanged.call(tokenApns);
     }
   }
 
@@ -205,7 +203,7 @@ class _NeoCoreFirebaseMessagingState extends State<NeoCoreFirebaseMessaging> {
   }
 
   Future<String?> _getAPNSTokenBasedOnPlatform() async {
-    if (kIsWeb || !Platform.isIOS) {
+    if (kIsWeb) {
       return null;
     }
     return NeoCoreFirebaseMessaging.firebaseMessaging.getAPNSToken();

--- a/lib/core/widgets/neo_core_firebase_messaging/neo_core_firebase_messaging.dart
+++ b/lib/core/widgets/neo_core_firebase_messaging/neo_core_firebase_messaging.dart
@@ -203,9 +203,6 @@ class _NeoCoreFirebaseMessagingState extends State<NeoCoreFirebaseMessaging> {
   }
 
   Future<String?> _getAPNSTokenBasedOnPlatform() async {
-    if (kIsWeb) {
-      return null;
-    }
     return NeoCoreFirebaseMessaging.firebaseMessaging.getAPNSToken();
   }
 

--- a/lib/core/widgets/neo_core_messaging/neo_core_messaging.dart
+++ b/lib/core/widgets/neo_core_messaging/neo_core_messaging.dart
@@ -23,6 +23,7 @@ class NeoCoreMessaging extends StatefulWidget {
   final NeoNetworkManager networkManager;
   final NeoCoreSecureStorage neoCoreSecureStorage;
   final Function(String) onTokenChanged;
+  final Function(String) onAPNSTokenChanged;
   final String? androidDefaultIcon;
   final Function(String)? onDeeplinkNavigation;
 
@@ -32,6 +33,7 @@ class NeoCoreMessaging extends StatefulWidget {
     required this.networkManager,
     required this.neoCoreSecureStorage,
     required this.onTokenChanged,
+    required this.onAPNSTokenChanged,
     this.androidDefaultIcon,
     this.onDeeplinkNavigation,
     super.key,
@@ -74,6 +76,7 @@ class _NeoCoreMessagingState extends State<NeoCoreMessaging> {
           networkManager: widget.networkManager,
           neoCoreSecureStorage: widget.neoCoreSecureStorage,
           onTokenChanged: widget.onTokenChanged,
+          onAPNSTokenChanged: widget.onAPNSTokenChanged,
           androidDefaultIcon: widget.androidDefaultIcon,
           onDeeplinkNavigation: widget.onDeeplinkNavigation,
           child: widget.child,

--- a/lib/core/widgets/neo_core_messaging/neo_core_messaging.dart
+++ b/lib/core/widgets/neo_core_messaging/neo_core_messaging.dart
@@ -23,7 +23,6 @@ class NeoCoreMessaging extends StatefulWidget {
   final NeoNetworkManager networkManager;
   final NeoCoreSecureStorage neoCoreSecureStorage;
   final Function(String) onTokenChanged;
-  final Function(String) onAPNSTokenChanged;
   final String? androidDefaultIcon;
   final Function(String)? onDeeplinkNavigation;
 
@@ -33,7 +32,6 @@ class NeoCoreMessaging extends StatefulWidget {
     required this.networkManager,
     required this.neoCoreSecureStorage,
     required this.onTokenChanged,
-    required this.onAPNSTokenChanged,
     this.androidDefaultIcon,
     this.onDeeplinkNavigation,
     super.key,
@@ -76,7 +74,6 @@ class _NeoCoreMessagingState extends State<NeoCoreMessaging> {
           networkManager: widget.networkManager,
           neoCoreSecureStorage: widget.neoCoreSecureStorage,
           onTokenChanged: widget.onTokenChanged,
-          onAPNSTokenChanged: widget.onAPNSTokenChanged,
           androidDefaultIcon: widget.androidDefaultIcon,
           onDeeplinkNavigation: widget.onDeeplinkNavigation,
           child: widget.child,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced support for APNS token retrieval on iOS devices.
	- Enhanced notification initialization to manage both Firebase and APNS tokens.
  
- **Bug Fixes**
	- Improved token management to ensure proper handling of platform-specific tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->