### PR TITLE
Develop: Use android_id package for android device ids

### DIFF
--- a/lib/core/util/device_util/device_util.dart
+++ b/lib/core/util/device_util/device_util.dart
@@ -10,6 +10,7 @@
  * Any reproduction of this material must contain this notice.
  */
 
+import 'package:android_id/android_id.dart';
 import 'package:device_info_plus/device_info_plus.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:neo_core/core/util/device_util/models/neo_device_info.dart';
@@ -25,8 +26,8 @@ class DeviceUtil {
       final iosInfo = await deviceInfo.iosInfo;
       return iosInfo.identifierForVendor;
     } else if (Platform.isAndroid) {
-      final androidInfo = await deviceInfo.androidInfo;
-      return androidInfo.id;
+      final androidId = await const AndroidId().getId();
+      return androidId ?? UuidUtil.generateUUID();
     } else {
       return null;
     }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -33,6 +33,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.2.0"
+  android_id:
+    dependency: "direct main"
+    description:
+      name: android_id
+      sha256: "748ba5f93dd5c497e675d8eaa1404346ce4d1794464ea654576ff192d153b92a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.0"
   args:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,7 @@ dependencies:
 
   # Utility
   uuid: ^4.1.0
+  android_id: ^0.4.0
 
   # Feature
   firebase_core: 3.1.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced device ID retrieval for Android devices, now with a fallback to generate a UUID if the Android ID is unavailable.
	- Added a new dependency to support the updated device ID functionality.

- **Bug Fixes**
	- Improved reliability of device ID fetching mechanism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->