### PR TITLE
Develop: Set android id from client side

### DIFF
--- a/lib/core/storage/neo_core_parameter_key.dart
+++ b/lib/core/storage/neo_core_parameter_key.dart
@@ -24,7 +24,7 @@ abstract class NeoCoreParameterKey {
   static const secureStorageCustomerNo = "secureStorage:common:customerNo";
   static const secureStorageCustomerSurname = "secureStorage:common:customerSurname";
   static const secureStorageCustomerNameAndSurnameUppercase = "secureStorage:common:customerNameAndSurnameUppercase";
-  static const secureStorageDeviceId = "secureStorage:infrastructure:deviceId";
+  static const secureStorageDeviceId = "secureStorage:infrastructure:deviceIdV2";
   static const secureStorageDeviceInfo = "secureStorage:infrastructure:deviceInformation";
   static const secureStorageDeviceRegistrationToken = "secureStorage:infrastructure:deviceRegistrationToken";
   static const secureStorageInstallationId = "secureStorage:infrastructure:installationId";

--- a/lib/core/util/device_util/device_util.dart
+++ b/lib/core/util/device_util/device_util.dart
@@ -10,7 +10,6 @@
  * Any reproduction of this material must contain this notice.
  */
 
-import 'package:android_id/android_id.dart';
 import 'package:device_info_plus/device_info_plus.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:neo_core/core/util/device_util/models/neo_device_info.dart';
@@ -18,6 +17,8 @@ import 'package:neo_core/core/util/uuid_util.dart';
 import 'package:universal_io/io.dart';
 
 class DeviceUtil {
+  static String? _androidId;
+
   Future<String?> getDeviceId() async {
     final deviceInfo = DeviceInfoPlugin();
     if (kIsWeb) {
@@ -26,11 +27,14 @@ class DeviceUtil {
       final iosInfo = await deviceInfo.iosInfo;
       return iosInfo.identifierForVendor;
     } else if (Platform.isAndroid) {
-      final androidId = await const AndroidId().getId();
-      return androidId ?? UuidUtil.generateUUID();
+      return _androidId ?? UuidUtil.generateUUID();
     } else {
       return null;
     }
+  }
+
+  static void setAndroidId(String androidId) {
+    _androidId = androidId;
   }
 
   Future<NeoDeviceInfo?> getDeviceInfo() async {

--- a/lib/neo_core.dart
+++ b/lib/neo_core.dart
@@ -12,6 +12,7 @@
 
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:neo_core/core/util/device_util/device_util.dart';
 import 'package:universal_io/io.dart';
 
 export 'core/bus/neo_bus.dart';
@@ -24,9 +25,12 @@ export 'core/widgets/neo_widgets.dart';
 class NeoCore {
   NeoCore._();
 
-  static Future init() async {
+  static Future init({String? androidId}) async {
     if (!kIsWeb && !Platform.isMacOS) {
       await Firebase.initializeApp();
+    }
+    if (androidId != null) {
+      DeviceUtil.setAndroidId(androidId);
     }
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -33,14 +33,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.2.0"
-  android_id:
-    dependency: "direct main"
-    description:
-      name: android_id
-      sha256: "748ba5f93dd5c497e675d8eaa1404346ce4d1794464ea654576ff192d153b92a"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.4.0"
   args:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,7 +38,6 @@ dependencies:
 
   # Utility
   uuid: ^4.1.0
-  android_id: ^0.4.0
 
   # Feature
   firebase_core: 3.1.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced device ID management with more flexible initialization
	- Added ability to set Android device ID during core initialization

- **Changes**
	- Updated secure storage device ID parameter key
	- Removed direct dependency on `android_id` package
	- Modified device ID retrieval mechanism

- **Improvements**
	- More robust device identification process
	- Simplified device ID management across the application

<!-- end of auto-generated comment: release notes by coderabbit.ai -->