### PR TITLE
Develop: Depend HttpClientConfig directly instead of sub-fields

### DIFF
--- a/lib/core/analytics/neo_logger.dart
+++ b/lib/core/analytics/neo_logger.dart
@@ -23,6 +23,7 @@ import 'package:neo_core/core/analytics/neo_crashlytics.dart';
 import 'package:neo_core/core/analytics/neo_elastic.dart';
 import 'package:neo_core/core/analytics/neo_logger_type.dart';
 import 'package:neo_core/core/analytics/neo_posthog.dart';
+import 'package:neo_core/core/network/models/http_client_config.dart';
 import 'package:neo_core/core/network/models/neo_page_type.dart';
 import 'package:neo_core/core/util/device_util/device_util.dart';
 import 'package:posthog_flutter/posthog_flutter.dart';
@@ -48,15 +49,18 @@ class NeoLogger implements INeoLogger {
   final NeoPosthog neoPosthog;
   final NeoAdjust neoAdjust;
   final NeoElastic neoElastic;
-  final Level logLevel;
+  final HttpClientConfig httpClientConfig;
 
   NeoLogger({
     required this.neoPosthog,
     required this.neoAdjust,
     required this.neoElastic,
-    required this.logLevel,
+    required this.httpClientConfig,
   });
 
+  // Getter is required, config may change at runtime
+  Level get _logLevel => httpClientConfig.config.logLevel;
+  
   final DeviceUtil _deviceUtil = DeviceUtil();
 
   final Logger _logger = Logger(printer: _NeoLoggerPrinter(), output: _NeoLoggerOutput());
@@ -100,7 +104,7 @@ class NeoLogger implements INeoLogger {
     Map<String, dynamic>? properties,
     Map<String, dynamic>? options,
   }) {
-    if (this.logLevel.value > logLevel.value || logLevel == Level.off || logLevel == Level.nothing) {
+    if (_logLevel.value > logLevel.value || logLevel == Level.off || logLevel == Level.nothing) {
       return;
     }
     if (logTypes.contains(NeoLoggerType.logger)) {

--- a/lib/core/storage/neo_core_secure_storage.dart
+++ b/lib/core/storage/neo_core_secure_storage.dart
@@ -27,10 +27,13 @@ abstract class _Constants {
 }
 
 class NeoCoreSecureStorage {
-  final bool enableCaching;
   final NeoSharedPrefs neoSharedPrefs;
+  final HttpClientConfig httpClientConfig;
 
-  NeoCoreSecureStorage({required this.neoSharedPrefs, required this.enableCaching});
+  NeoCoreSecureStorage({required this.neoSharedPrefs, required this.httpClientConfig});
+
+  // Getter is required, config may change at runtime
+  bool get _enableCaching => httpClientConfig.config.cacheStorage;
 
   FlutterSecureStorage? _storage;
 
@@ -39,7 +42,7 @@ class NeoCoreSecureStorage {
   NeoLogger get _neoLogger => GetIt.I.get();
 
   Future<void> write({required String key, required String? value}) {
-    if (enableCaching) {
+    if (_enableCaching) {
       _cachedValues[key] = value;
     }
 
@@ -47,7 +50,7 @@ class NeoCoreSecureStorage {
   }
 
   Future<String?> read(String key) async {
-    if (enableCaching && _cachedValues.containsKey(key)) {
+    if (_enableCaching && _cachedValues.containsKey(key)) {
       return _cachedValues[key];
     } else if (await _storage!.containsKey(key: key)) {
       String? value;
@@ -65,7 +68,7 @@ class NeoCoreSecureStorage {
   }
 
   Future<void> delete(String key) {
-    if (enableCaching) {
+    if (_enableCaching) {
       _cachedValues.remove(key);
     }
 
@@ -73,7 +76,7 @@ class NeoCoreSecureStorage {
   }
 
   Future<void> deleteAll() {
-    if (enableCaching) {
+    if (_enableCaching) {
       _cachedValues.clear();
     }
 

--- a/lib/core/storage/neo_shared_prefs.dart
+++ b/lib/core/storage/neo_shared_prefs.dart
@@ -13,14 +13,18 @@
 import 'package:get_it/get_it.dart';
 import 'package:logger/logger.dart';
 import 'package:neo_core/core/analytics/neo_logger.dart';
+import 'package:neo_core/core/network/models/http_client_config.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class NeoSharedPrefs {
-  final bool enableCaching;
+  final HttpClientConfig httpClientConfig;
 
   NeoSharedPrefs({
-    required this.enableCaching,
+    required this.httpClientConfig,
   });
+
+  // Getter is required, config may change at runtime
+  bool get _enableCaching => httpClientConfig.config.cacheStorage;
 
   NeoLogger get _neoLogger => GetIt.I.get();
 
@@ -36,7 +40,7 @@ class NeoSharedPrefs {
   }
 
   Object? read(String key) {
-    if (enableCaching && _cachedValues.containsKey(key)) {
+    if (_enableCaching && _cachedValues.containsKey(key)) {
       return _cachedValues[key];
     }
 
@@ -47,7 +51,7 @@ class NeoSharedPrefs {
   }
 
   Future<bool> write(String key, Object value) {
-    if (enableCaching) {
+    if (_enableCaching) {
       _cachedValues[key] = value;
     }
 
@@ -71,7 +75,7 @@ class NeoSharedPrefs {
   }
 
   Future<bool> delete(String key) {
-    if (enableCaching) {
+    if (_enableCaching) {
       _cachedValues.remove(key);
     }
 
@@ -79,7 +83,7 @@ class NeoSharedPrefs {
   }
 
   Future<bool> clear() {
-    if (enableCaching) {
+    if (_enableCaching) {
       _cachedValues.clear();
     }
 


### PR DESCRIPTION
Http client config may change at runtime

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration Changes**
	- Introduced a new `HttpClientConfig` across multiple core services
	- Replaced direct configuration properties with dynamic runtime configuration
	- Updated constructors to use centralized configuration management

- **Logging Enhancements**
	- Modified log level retrieval mechanism in `NeoLogger`
	- Decoupled log level from direct class properties

- **Storage Improvements**
	- Updated caching configuration in `NeoCoreSecureStorage` and `NeoSharedPrefs`
	- Enabled more flexible runtime caching behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->