### PR TITLE
mTLS: Decrypt encrypted responses when x-encrypt flag is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
 # CHANGELOG
 
-## [1.0.0]
+## [1.0.1]
+### Added
+- mTLS: Decrypt encrypted responses when x-encrypt flag is set

--- a/lib/core/network/helpers/mtls_helper.dart
+++ b/lib/core/network/helpers/mtls_helper.dart
@@ -50,4 +50,13 @@ class MtlsHelper {
     final privateKeyResult = await _secureEnclavePlugin.getServerKey(tag: clientKeyTag);
     return privateKeyResult.value;
   }
+
+  Future<String?> decrypt({required String clientKeyTag, required Uint8List message}) async {
+    final result = await _secureEnclavePlugin.decrypt(message: message, tag: clientKeyTag);
+    return result.value;
+  }
+
+  Future<ResultModel<String?>> decryptWithAES({required Uint8List encryptedData, required Uint8List aesKey}) {
+    return _secureEnclavePlugin.decryptWithAES(encryptedData: encryptedData, aesKey: aesKey);
+  }
 }

--- a/lib/core/network/interceptors/neo_response_interceptor.dart
+++ b/lib/core/network/interceptors/neo_response_interceptor.dart
@@ -2,11 +2,15 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart';
+import 'package:get_it/get_it.dart';
 import 'package:http/http.dart';
+import 'package:logger/logger.dart';
+import 'package:neo_core/core/analytics/neo_logger.dart';
 import 'package:neo_core/core/network/helpers/mtls_helper.dart';
 import 'package:neo_core/core/network/models/neo_network_header_key.dart';
 import 'package:neo_core/core/storage/neo_core_parameter_key.dart';
 import 'package:neo_core/core/storage/neo_core_secure_storage.dart';
+import 'package:neo_core/core/util/extensions/get_it_extensions.dart';
 
 class NeoResponseInterceptor {
   final dynamic body;
@@ -21,45 +25,54 @@ class NeoResponseInterceptor {
     required this.mtlsHelper,
   });
 
+  NeoLogger? get _neoLogger => GetIt.I.getIfReady<NeoLogger>();
+
   Future<dynamic> intercept() async {
     if (response.headers[NeoNetworkHeaderKey.encrypt] != "true") {
       return body;
     }
 
-    final result = await Future.wait([
-      secureStorage.read(NeoCoreParameterKey.secureStorageCustomerId),
-      secureStorage.read(NeoCoreParameterKey.secureStorageDeviceId),
-    ]);
+    try {
+      final result = await Future.wait([
+        secureStorage.read(NeoCoreParameterKey.secureStorageCustomerId),
+        secureStorage.read(NeoCoreParameterKey.secureStorageDeviceId),
+      ]);
 
-    final userReference = result[0];
-    final deviceId = result[1];
-    final clientKeyTag = "$deviceId$userReference";
+      final userReference = result[0];
+      final deviceId = result[1];
+      final clientKeyTag = "$deviceId$userReference";
 
-    final encryptedKey = body["data"]["encryptedKey"];
-    final encryptedData = body["data"]["encryptData"];
-    final encryptedKeyBytes = base64.decode(encryptedKey);
-    final aesKeyString = await mtlsHelper.decrypt(
-      clientKeyTag: clientKeyTag,
-      message: Uint8List.fromList(encryptedKeyBytes),
-    );
+      final encryptedKey = body["data"]["encryptedKey"];
+      final encryptedData = body["data"]["encryptData"];
+      final encryptedKeyBytes = base64.decode(encryptedKey);
+      final aesKeyString = await mtlsHelper.decrypt(
+        clientKeyTag: clientKeyTag,
+        message: Uint8List.fromList(encryptedKeyBytes),
+      );
 
-    if (aesKeyString == null) {
+      if (aesKeyString == null) {
+        _neoLogger?.logCustom("Aes key is null", logLevel: Level.fatal);
+        return body;
+      }
+
+      final aesKeyBytes = base64.decode(aesKeyString);
+      final encryptedDataBytes = base64.decode(encryptedData);
+      final aesDecryptResult = await mtlsHelper.decryptWithAES(
+        encryptedData: Uint8List.fromList(encryptedDataBytes),
+        aesKey: Uint8List.fromList(aesKeyBytes),
+      );
+
+      final decryptedText = aesDecryptResult.value;
+      if (decryptedText == null) {
+        _neoLogger?.logCustom("Decrypted text is null", logLevel: Level.fatal);
+        return body;
+      }
+
+      final decryptedBody = jsonDecode(utf8.decode(base64Decode(jsonDecode(decryptedText)["data"])));
+      return decryptedBody;
+    } catch (e) {
+      _neoLogger?.logCustom("Response interception failed. $e", logLevel: Level.fatal);
       return body;
     }
-
-    final aesKeyBytes = base64.decode(aesKeyString);
-    final encryptedDataBytes = base64.decode(encryptedData);
-    final aesDecryptResult = await mtlsHelper.decryptWithAES(
-      encryptedData: Uint8List.fromList(encryptedDataBytes),
-      aesKey: Uint8List.fromList(aesKeyBytes),
-    );
-
-    final decryptedText = aesDecryptResult.value;
-    if (decryptedText == null) {
-      return body;
-    }
-
-    final decryptedBody = jsonDecode(utf8.decode(base64Decode(jsonDecode(decryptedText)["data"])));
-    return decryptedBody;
   }
 }

--- a/lib/core/network/interceptors/neo_response_interceptor.dart
+++ b/lib/core/network/interceptors/neo_response_interceptor.dart
@@ -1,0 +1,65 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart';
+import 'package:neo_core/core/network/helpers/mtls_helper.dart';
+import 'package:neo_core/core/network/models/neo_network_header_key.dart';
+import 'package:neo_core/core/storage/neo_core_parameter_key.dart';
+import 'package:neo_core/core/storage/neo_core_secure_storage.dart';
+
+class NeoResponseInterceptor {
+  final dynamic body;
+  final Response response;
+  final NeoCoreSecureStorage secureStorage;
+  final MtlsHelper mtlsHelper;
+
+  NeoResponseInterceptor({
+    required this.body,
+    required this.response,
+    required this.secureStorage,
+    required this.mtlsHelper,
+  });
+
+  Future<dynamic> intercept() async {
+    if (response.headers[NeoNetworkHeaderKey.encrypt] != "true") {
+      return body;
+    }
+
+    final result = await Future.wait([
+      secureStorage.read(NeoCoreParameterKey.secureStorageCustomerId),
+      secureStorage.read(NeoCoreParameterKey.secureStorageDeviceId),
+    ]);
+
+    final userReference = result[0];
+    final deviceId = result[1];
+    final clientKeyTag = "$deviceId$userReference";
+
+    final encryptedKey = body["data"]["encryptedKey"];
+    final encryptedData = body["data"]["encryptData"];
+    final encryptedKeyBytes = base64.decode(encryptedKey);
+    final aesKeyString = await mtlsHelper.decrypt(
+      clientKeyTag: clientKeyTag,
+      message: Uint8List.fromList(encryptedKeyBytes),
+    );
+
+    if (aesKeyString == null) {
+      return body;
+    }
+
+    final aesKeyBytes = base64.decode(aesKeyString);
+    final encryptedDataBytes = base64.decode(encryptedData);
+    final aesDecryptResult = await mtlsHelper.decryptWithAES(
+      encryptedData: Uint8List.fromList(encryptedDataBytes),
+      aesKey: Uint8List.fromList(aesKeyBytes),
+    );
+
+    final decryptedText = aesDecryptResult.value;
+    if (decryptedText == null) {
+      return body;
+    }
+
+    final decryptedBody = jsonDecode(utf8.decode(base64Decode(jsonDecode(decryptedText)["data"])));
+    return decryptedBody;
+  }
+}

--- a/lib/core/network/managers/neo_network_manager.dart
+++ b/lib/core/network/managers/neo_network_manager.dart
@@ -27,6 +27,7 @@ import 'package:neo_core/core/network/headers/mtls_headers.dart';
 import 'package:neo_core/core/network/headers/neo_constant_headers.dart';
 import 'package:neo_core/core/network/headers/neo_dynamic_headers.dart';
 import 'package:neo_core/core/network/helpers/mtls_helper.dart';
+import 'package:neo_core/core/network/interceptors/neo_response_interceptor.dart';
 import 'package:neo_core/core/network/models/http_auth_response.dart';
 import 'package:neo_core/core/network/models/http_method.dart';
 import 'package:neo_core/core/network/models/neo_http_call.dart';
@@ -302,7 +303,13 @@ class NeoNetworkManager {
     try {
       const utf8Decoder = Utf8Decoder();
       final responseString = utf8Decoder.convert(response.bodyBytes);
-      final decodedResponse = json.decode(responseString);
+      var decodedResponse = json.decode(responseString);
+      decodedResponse = await NeoResponseInterceptor(
+        body: decodedResponse,
+        response: response,
+        secureStorage: secureStorage,
+        mtlsHelper: _mtlsHelper,
+      ).intercept();
       if (decodedResponse is Map<String, dynamic>) {
         responseJSON = decodedResponse;
       } else {

--- a/lib/core/network/models/neo_network_header_key.dart
+++ b/lib/core/network/models/neo_network_header_key.dart
@@ -27,6 +27,7 @@ abstract class NeoNetworkHeaderKey {
   static const deviceModel = "X-Device-Model";
   static const devicePlatform = "X-Device-Platform";
   static const deviceVersion = "X-Device-Version";
+  static const encrypt = "x-encrpt";
   static const googleServiceAvailable = "X-Google-Service-Available";
   static const ifNoneMatch = "If-None-Match";
   static const installationId = "X-Installation-Id";

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -527,8 +527,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "v1.0.16"
-      resolved-ref: b7e9c2f4dc4dfee5f6dd0904e770680981007527
+      ref: "v1.0.17"
+      resolved-ref: "177b16d1dd6a40323548b5a2f9a329681411ff1b"
       url: "https://github.com/amorphie/flutter.shield"
     source: git
     version: "0.1.1"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -68,7 +68,7 @@ dependencies:
   flutter_shield:
     git:
       url: https://github.com/amorphie/flutter.shield
-      ref: v1.0.16
+      ref: v1.0.17
 
 dependency_overrides:
   web: 1.0.0 # TODO: Update other dependencies and delete this override


### PR DESCRIPTION
Related to: 341074

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Responses encrypted during mTLS communications are now automatically decrypted when the relevant header flag is set.

* **Chores**
  * Updated dependency for improved security features.
  * Updated documentation to reflect the latest changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->